### PR TITLE
Run as a service daemon

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kardianos/osext"
 	//"github.com/sanbornm/go-selfupdate/selfupdate" #included in update.go to change heavily
 	//"github.com/sanderhahn/gozip"
+	"github.com/kardianos/service"
 	"github.com/vharitonsky/iniflags"
 	"runtime/debug"
 	"text/template"
@@ -81,7 +82,55 @@ func launchSelfLater() {
 	log.Println("Done waiting 5 secs. Now launching...")
 }
 
+var logger service.Logger
+
+type program struct{}
+
+func (p *program) Start(s service.Service) error {
+	// Start should not block. Do the actual work async.
+	go p.run()
+	return nil
+}
+func (p *program) run() {
+	startDaemon()
+}
+func (p *program) Stop(s service.Service) error {
+	// Stop should not block. Return with a few seconds.
+	<-time.After(time.Second * 13)
+	return nil
+}
+
 func main() {
+	svcConfig := &service.Config{
+		Name:        "ArduinoCreateBridge",
+		DisplayName: "Arduino Create Bridge",
+		Description: "A bridge that allows Arduino Create to operate on the boards connected to the computer",
+	}
+
+	prg := &program{}
+	s, err := service.New(prg, svcConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(os.Args) > 1 {
+		err = service.Control(s, os.Args[1])
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	logger, err = s.Logger(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = s.Run()
+	if err != nil {
+		logger.Error(err)
+	}
+}
+
+func startDaemon() {
 
 	go func() {
 
@@ -208,7 +257,7 @@ func main() {
 			}
 		}()
 	}()
-	setupSysTray()
+	// setupSysTray()
 }
 
 func externalIP() (string, error) {

--- a/main.go
+++ b/main.go
@@ -124,6 +124,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	err = s.Install()
+	if err != nil {
+		logger.Error(err)
+	}
+
 	err = s.Run()
 	if err != nil {
 		logger.Error(err)


### PR DESCRIPTION
Once you compiled it you can launch it with

`# Arduino_Create_Bridge install`

and it will install on the computer as a service.

I had to disable the trayicon until we find a way of making it work.

Tested on ubuntu
